### PR TITLE
Update language_en.h with Host Prompt text

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -354,7 +354,7 @@ void disable_all_steppers() {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_prompt_reason = PROMPT_FILAMENT_RUNOUT;
       host_action_prompt_end();
-      host_action_prompt_begin(PSTR("FilamentRunout T"), false);
+      host_action_prompt_begin(PSTR(MSG_HOST_FILAMENT_RUNOUT), false);
       SERIAL_CHAR(tool);
       SERIAL_EOL();
       host_action_prompt_show();
@@ -414,7 +414,7 @@ void disable_all_steppers() {
 
   void event_probe_recover() {
     #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"), PSTR("Dismiss"));
+      host_prompt_do(PROMPT_INFO, PSTR(MSG_HOST_G29RETRY), PSTR(MSG_HOST_DISMISS));
     #endif
     #ifdef ACTION_ON_G29_RECOVER
       host_action(PSTR(ACTION_ON_G29_RECOVER));

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -524,7 +524,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
   KEEPALIVE_STATE(PAUSED_FOR_USER);
   wait_for_user = true;    // LCD click or M108 will clear this
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_NOZZLE_PARKED), PSTR(MSG_HOST_CONTINUE);
+    host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_NOZZLE_PARKED), PSTR(MSG_HOST_CONTINUE));
   #endif
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onUserConfirmRequired(PSTR("Nozzle Parked"));

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -402,7 +402,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
   #endif
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    host_prompt_open(PROMPT_INFO, PSTR("Pause"), PSTR("Dismiss"));
+    host_prompt_open(PROMPT_INFO, PSTR(MSG_HOST_PAUSE), PSTR(MSG_HOST_DISMISS));
   #endif
 
   if (!DEBUGGING(DRYRUN) && unload_length && thermalManager.targetTooColdToExtrude(active_extruder)) {

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -181,10 +181,10 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
       ;
       host_prompt_reason = PROMPT_USER_CONTINUE;
       host_action_prompt_end();
-      host_action_prompt_begin(PSTR("Load Filament T"), false);
+      host_action_prompt_begin(PSTR(MSG_HOST_LOAD_FILAMENT), false);
       SERIAL_CHAR(tool);
       SERIAL_EOL();
-      host_action_prompt_button(PSTR("Continue"));
+      host_action_prompt_button(MSG_HOST_CONTINUE);
       host_action_prompt_show();
     #endif
     #if ENABLED(EXTENSIBLE_UI)
@@ -240,7 +240,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
 
     wait_for_user = true;
     #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Continuous Purge Running..."), PSTR("Continue"));
+      host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_CONTINUOUS_PURGE), PSTR(MSG_HOST_CONTINUE));
     #endif
     #if ENABLED(EXTENSIBLE_UI)
       ExtUI::onUserConfirmRequired(PSTR("Continuous Purge Running..."));
@@ -273,10 +273,10 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
             || runout.filament_ran_out
           #endif
         )
-          host_action_prompt_button(PSTR("DisableRunout"));
+          host_action_prompt_button(PSTR(MSG_HOST_DISABLE_RUNOUT));
         else {
           host_prompt_reason = PROMPT_FILAMENT_RUNOUT;
-          host_action_prompt_button(PSTR("Continue"));
+          host_action_prompt_button(PSTR(MSG_HOST_CONTINUE));
         }
         host_action_prompt_show();
       #endif
@@ -524,7 +524,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
   KEEPALIVE_STATE(PAUSED_FOR_USER);
   wait_for_user = true;    // LCD click or M108 will clear this
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Nozzle Parked"), PSTR("Continue"));
+    host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_NOZZLE_PARKED), PSTR(MSG_HOST_CONTINUE);
   #endif
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onUserConfirmRequired(PSTR("Nozzle Parked"));
@@ -547,7 +547,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       SERIAL_ECHO_MSG(_PMSG(MSG_FILAMENT_CHANGE_HEAT));
 
       #if ENABLED(HOST_PROMPT_SUPPORT)
-        host_prompt_do(PROMPT_USER_CONTINUE, PSTR("HeaterTimeout"), PSTR("Reheat"));
+        host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_HEATER_TIMEOUT), PSTR(MSG_HOST_REHEAT));
       #endif
 
       #if ENABLED(EXTENSIBLE_UI)
@@ -558,7 +558,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       while (wait_for_user) idle(true);
 
       #if ENABLED(HOST_PROMPT_SUPPORT)
-        host_prompt_do(PROMPT_INFO, PSTR("Reheating"));
+        host_prompt_do(PROMPT_INFO, PSTR(MSG_HOST_REHEATING));
       #endif
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onStatusChanged(PSTR("Reheating..."));
@@ -578,7 +578,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
 
       HOTEND_LOOP() thermalManager.hotend_idle[e].start(nozzle_timeout);
       #if ENABLED(HOST_PROMPT_SUPPORT)
-        host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Reheat Done"), PSTR("Continue"));
+        host_prompt_do(PROMPT_USER_CONTINUE, PSTR(MSG_HOST_REHEAT_DONE), PSTR(MSG_HOST_CONTINUE));
       #endif
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onUserConfirmRequired("Reheat finished.");
@@ -681,7 +681,7 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   --did_pause_print;
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    host_prompt_open(PROMPT_INFO, PSTR("Resuming"), PSTR("Dismiss"));
+    host_prompt_open(PROMPT_INFO, PSTR(MSG_HOST_RESUMING), PSTR(MSG_HOST_DISMISS));
   #endif
 
   #if ENABLED(SDSUPPORT)

--- a/Marlin/src/gcode/sdcard/M24_M25.cpp
+++ b/Marlin/src/gcode/sdcard/M24_M25.cpp
@@ -100,7 +100,7 @@ void GcodeSuite::M25() {
 
     #if ENABLED(HOST_ACTION_COMMANDS)
       #if ENABLED(HOST_PROMPT_SUPPORT)
-        host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("Pause SD"), PSTR("Resume"));
+        host_prompt_open(PROMPT_PAUSE_RESUME, PSTR(MSG_HOST_PAUSE_SD), PSTR(MSG_HOST_RESUME));
       #endif
       #ifdef ACTION_ON_PAUSE
         host_action_pause();

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1576,3 +1576,21 @@
 #ifndef MSG_BACKLASH_SMOOTHING
   #define MSG_BACKLASH_SMOOTHING              _UxGT("Smoothing")
 #endif
+
+// Host Prompt Messages
+#ifndef MSG_HOST_DISMISS
+  #define MSG_HOST_DISMISS                    _UxGT("Dismiss")
+#endif
+#ifndef MSG_HOST_RESUME
+  #define MSG_HOST_RESUME                     _UxGT("Resume")
+#endif
+
+#ifndef MSG_HOST_ABORT
+  #define MSG_HOST_ABORT                      _UxGT("UI Abort")
+#endif
+#ifndef MSG_HOST_PAUSE
+  #define MSG_HOST_PAUSE                      _UxGT("UI Pause")
+#endif
+
+
+

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1584,6 +1584,9 @@
 #ifndef MSG_HOST_RESUME
   #define MSG_HOST_RESUME                     _UxGT("Resume")
 #endif
+#ifndef MSG_HOST_CONTINUE
+  #define MSG_HOST_CONTINUE                    _UxGT("Continue")
+#endif
 
 #ifndef MSG_HOST_ABORT
   #define MSG_HOST_ABORT                      _UxGT("UI Abort")
@@ -1591,6 +1594,27 @@
 #ifndef MSG_HOST_PAUSE
   #define MSG_HOST_PAUSE                      _UxGT("UI Pause")
 #endif
+#ifndef MSG_HOST_FILAMENT_RUNOUT
+  #define MSG_HOST_FILAMENT_RUNOUT            _UxGT("FilamentRunout T")
+#endif
+#ifndef MSG_HOST_G29RETRY
+  #define MSG_HOST_G29RETRY                   _UxGT("G29 Retrying")
+#endif
+#ifndef MSG_HOST_LOAD_FILAMENT
+  #define MSG_HOST_LOAD_FILAMENT              _UxGT("Load Filament T")
+#endif
+#ifndef MSG_HOST_CONTINUOUS_PURGE
+  #define MSG_HOST_CONTINUOUS_PURGE           _UxGT("Continuous Purge Running...")
+#endif
+#ifndef MSG_HOST_DISABLE_RUNOUT
+  #define MSG_HOST_DISABLE_RUNOUT                      _UxGT("DisableRunout")
+#endif
+#ifndef MSG_HOST_NOZZLE_PARKED
+  #define MSG_HOST_NOZZLE_PARKED                      _UxGT("Nozzle Parked")
+#endif
+
+
+
 
 
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1585,7 +1585,7 @@
   #define MSG_HOST_RESUME                     _UxGT("Resume")
 #endif
 #ifndef MSG_HOST_CONTINUE
-  #define MSG_HOST_CONTINUE                    _UxGT("Continue")
+  #define MSG_HOST_CONTINUE                   _UxGT("Continue")
 #endif
 
 #ifndef MSG_HOST_ABORT
@@ -1607,11 +1607,29 @@
   #define MSG_HOST_CONTINUOUS_PURGE           _UxGT("Continuous Purge Running...")
 #endif
 #ifndef MSG_HOST_DISABLE_RUNOUT
-  #define MSG_HOST_DISABLE_RUNOUT                      _UxGT("DisableRunout")
+  #define MSG_HOST_DISABLE_RUNOUT             _UxGT("DisableRunout")
 #endif
 #ifndef MSG_HOST_NOZZLE_PARKED
-  #define MSG_HOST_NOZZLE_PARKED                      _UxGT("Nozzle Parked")
+  #define MSG_HOST_NOZZLE_PARKED              _UxGT("Nozzle Parked")
 #endif
+#ifndef MSG_HOST_HEATER_TIMEOUT
+  #define MSG_HOST_HEATER_TIMEOUT             _UxGT("HeaterTimeout")
+#endif
+#ifndef MSG_HOST_REHEAT
+  #define MSG_HOST_REHEAT                     _UxGT("Reheat")
+#endif
+#ifndef MSG_HOST_REHEATING
+  #define MSG_HOST_REHEATING                  _UxGT("Reheating")
+#endif
+#ifndef MSG_HOST_RESUMING
+  #define MSG_HOST_RESUMING                   _UxGT("Resuming")
+#endif
+#ifndef MSG_HOST_PAUSE_SD
+  #define MSG_HOST_PAUSE_SD                   _UxGT("Pause SD")
+#endif
+
+
+
 
 
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1618,6 +1618,9 @@
 #ifndef MSG_HOST_REHEAT
   #define MSG_HOST_REHEAT                     _UxGT("Reheat")
 #endif
+#ifndef MSG_HOST_REHEAT_DONE
+  #define MSG_HOST_REHEAT_DONE                _UxGT("Reheat Done")
+#endif
 #ifndef MSG_HOST_REHEATING
   #define MSG_HOST_REHEATING                  _UxGT("Reheating")
 #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1482,7 +1482,7 @@ void MarlinUI::update() {
       host_action_cancel();
     #endif
     #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_INFO, PSTR("UI Aborted"), PSTR("Dismiss"));
+      host_prompt_open(PROMPT_INFO, PSTR(MSG_HOST_ABORT), PSTR(MSG_HOST_DISMISS));
     #endif
     print_job_timer.stop();
     set_status_P(PSTR(MSG_PRINT_ABORTED));
@@ -1505,7 +1505,7 @@ void MarlinUI::update() {
     #endif
 
     #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
+      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR(MSG_HOST_PAUSE), PSTR(MSG_HOST_RESUME));
     #endif
 
     set_status_P(PSTR(MSG_PRINT_PAUSED));


### PR DESCRIPTION
### Description

Updates the host prompts to use strings defined in the language files.

### Benefits

Allows localization of host prompts
Moves text strings from logic files to header files

### Still undone
Add the string definitions to the other language (non English) files

Go through and catch a few strings I missed.